### PR TITLE
Replaced "Cassandra" with "Enterprise"

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: DataStax Cassandra Service Broker for PCF (Beta)
+title: DataStax Enterprise Service Broker for PCF (Beta)
 owner: Partners
 ---
 
@@ -16,26 +16,26 @@ owner: Partners
 
 <p class="note warning">
 <strong>IMPORTANT: </strong>
-The DataStax Cassandra Service Broker for PCF tile is currently in beta and is intended for evaluation and test purposes only. 
+The DataStax Enterprise Service Broker for PCF tile is currently in beta and is intended for evaluation and test purposes only. 
 Do not use this product in a PCF production environment.
 </p>
 
-This documentation describes the DataStax Cassandra Service Broker for PCF service.
+This documentation describes the DataStax Enteprise Service Broker for PCF service.
 
 DataStax Enterprise (DSE) is a distributed database service for cloud apps based on [Apache Cassandra](http://cassandra.apache.org/). DSE nodes sync automatically, and include indexing, search, analytics, and graph functions that help developers create intelligent and compelling cloud apps.
 
-DataStax Cassandra Service Broker for PCF lets PCF developers call DSE from their apps running on Pivotal Cloud Foundry (PCF).
+DataStax Enterprise Service Broker for PCF lets PCF developers call DSE from their apps running on Pivotal Cloud Foundry (PCF).
 
 ## <a id='overview'></a>Overview
 
-DataStax Cassandra Service Broker for PCF includes:
+DataStax Enterprise Service Broker for PCF includes:
 
-* A service broker that connects PCF apps to an existing DataStax Enterprise 5.0.x installation
+* A service broker that connects PCF apps to an existing DataStax Enterprise 5.x installation
 * Dynamic plan offerings that map to Cassandra roles
 
 ## <a id="snapshot"></a>Product Snapshot
 
-The following table provides version and version-support information about DataStax Cassandra Service Broker for PCF:
+The following table provides version and version-support information about DataStax Enterprise Service Broker for PCF:
 
 <table class="nice">
     <th>Element</th>
@@ -80,4 +80,4 @@ or send an email to [DataStax](mailto:partner-architecture@datastax.com).
 
 ## Further Reading
 
-* [Official DataStax Enterprise Cassandra Documentation](http://docs.datastax.com/en/datastax_enterprise/5.0/)
+* [Official DataStax Enterprise Documentation](http://docs.datastax.com/)


### PR DESCRIPTION
Replaced "Cassandra" with "Enterprise" for naming convention