### PR TITLE
Replaced "Cassandra" with "Enterprise"

### DIFF
--- a/docs-content/configuring.html.md.erb
+++ b/docs-content/configuring.html.md.erb
@@ -1,9 +1,9 @@
 ---
-title: Configuring DataStax Cassandra Service Broker for PCF
+title: Configuring DataStax Enterprise Service Broker for PCF
 owner: Partners
 ---
 
-To configure DataStax Cassandra Service Broker for PCF, navigate to the tile in the Ops Manager Installation Dashboard, click the tile to open its configuration tabs, and select the **Settings** tab.
+To configure DataStax Enterprise Service Broker for PCF, navigate to the tile in the Ops Manager Installation Dashboard, click the tile to open its configuration tabs, and select the **Settings** tab.
 
 The **Settings** tab includes the standard configuration panes **Assign AZs and Networks**, **Errands**, **Resource Config**, and **Stemcell**, shared by all Ops Manager tiles. 
 
@@ -25,7 +25,7 @@ This pane includes the following fields:
 
 ![Image of OpsManager Cassandra Cluster Configuration](images/cluster-settings.png)
 
-Pivotal Cloud Foundry (PCF) needs these fields from the external DataStax Enterprise Cassandra cluster, to allow access:
+Pivotal Cloud Foundry (PCF) needs these fields from the external DataStax Enterprise cluster, to allow access:
 
 * IP Address
 * Port (default: `9042`)
@@ -44,7 +44,7 @@ You can optionally set a **Cassandra Role** for each plan. When an app accesses 
 
 ## <a id='access'></a>Service Access
 
-By default, all service plans for the DataStax Enterprise Cassandra service are private.
+By default, all service plans for the DataStax Enterprise service are private.
 
 To make the service plans public, publishing them to the Services Marketplace, select **Enable global access to plans of service DataStax Cassandra Service Broker for PCF**.
 


### PR DESCRIPTION
Replaced "Cassandra" with "Enterprise" for naming convention