### PR TITLE
Replaced "Cassandra" with "Enterprise"

### DIFF
--- a/docs-content/using.html.md.erb
+++ b/docs-content/using.html.md.erb
@@ -1,25 +1,25 @@
 ---
-title: Using DataStax Cassandra Service Broker for PCF
+title: Using DataStax Enterprise Service Broker for PCF
 owner: Partners
 ---
 
-You can create service instances of DataStax Cassandra Service Broker for PCF and bind them to apps using either Apps Manager or the Cloud Foundry Command-Line Interface (cf CLI).
+You can create service instances of DataStax Enterprise Service Broker for PCF and bind them to apps using either Apps Manager or the Cloud Foundry Command-Line Interface (cf CLI).
 
-Download an example app that uses DataStax Cassandra Service Broker for PCF [here](https://github.com/mp911de/spring-music/tree/cassandra).
+Download an example app that uses DataStax Enterprise Service Broker for PCF [here](https://github.com/mp911de/spring-music/tree/cassandra).
 
 ## <a id="create"></a> Create a Service Instance
 
-Creating a service instance in PCF automatically creates an associated user account in the Cassandra cluster, to let the instance access the cluster. If the service plan specifies a Cassandra role, this user account has this role; otherwise the instance logs in as `admin`.
+Creating a service instance in PCF automatically creates an associated user account in the DataStax Enterprise cluster, to let the instance access the cluster. If the service plan specifies a Cassandra role, this user account has this role; otherwise the instance logs in as `admin`.
 
-The following procedures describe how to create a DataStax Cassandra service instance in Apps Manager and with the cf CLI.
+The following procedures describe how to create a DataStax Enterprise Service Broker for PCF service instance in Apps Manager and with the cf CLI.
 
 
 ### <a id="create-apps-man"></a> Pivotal Apps Manager
 
 1. From Apps Manager, select **Marketplace** from the left navigation menu under **Spaces**. This displays the Services Marketplace.
-1. Select **DataStax Cassandra Service Broker for PCF** from the tiles.
+1. Select **DataStax Enterprise Service Broker for PCF** from the tiles.
 1. Click on the **Select this plan** button to select the **Basic Service Plan**.
-1. In the **Instance Name** field, enter a name that will identify this specific DataStax Cassandra Service Broker for PCF service instance.
+1. In the **Instance Name** field, enter a name that will identify this specific DataStax Enterprise Service Broker for PCF service instance.
 1. From the **Add to Space** drop-down list, select the space where apps will bind to the service.
 1. Click the **Add** button to create the service instance.
 
@@ -46,14 +46,14 @@ The following procedures describe how to create a DataStax Cassandra service ins
 
 ## <a id="bind"></a>Bind an App to a Service Instance
 
-The following procedures describe how to bind a DataStax Enterprise Cassandra service instance to a PCF app using Pivotal Apps Manager or the cf CLI.
+The following procedures describe how to bind a DataStax Enterprise Service Broker for PCF service instance to a PCF app using Pivotal Apps Manager or the cf CLI.
 
 ### <a id="bind-apps-man"></a> Pivotal Apps Manager
 
 1. In a space, select the app to bind to the service.
 1. Select the **Services** tab for the app. A page displays showing the service instances that are already bound to this app.
 1. Click **Bind a Service**. A dropdown appears with a list of available service instances.
-1. Select the DataStax Enterprise Cassandra service instance you [created](#create) in the previous section and click **Bind**.
+1. Select the DataStax Enterprise Service Broker for PCF service instance you [created](#create) in the previous section and click **Bind**.
 1. Use the cf CLI to start or restage your application.
 
     <pre class="terminal">


### PR DESCRIPTION
Replaced "Cassandra" with "Enterprise" for naming convention