### PR TITLE
Replaced "Cassandra" with "Enterprise"

### DIFF
--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: DataStax Cassandra Service Broker for PCF Release Notes
+title: DataStax Enterprise Service Broker for PCF Release Notes
 owner: Partners
 ---
 


### PR DESCRIPTION
Replaced "Cassandra" with "Enterprise" for naming convention